### PR TITLE
Revert the v0.0.17 release

### DIFF
--- a/autorender.js
+++ b/autorender.js
@@ -11,20 +11,9 @@ import 'can-react/extensions/';
 
 // Determine if we are in the browser or server - this could maybe be smarter...
 const IS_BROWSER = typeof global === "undefined";
-const noop = function () { };
 
-export default function (AppComponent) {
-  //!steal-remove-start
-  if (AppComponent.prototype.getInitialState) {
-    throw new Error ("You cannot use getInitialState on the app component. The server side rendering engine will instatiate your app's viewmodel and set the state accordingly. If you need custom initialization logic, use the viewmodel init() function or any of the other React Component lifecycle events.");
-  }
-  if (!AppComponent.prototype.ViewModel) {
-    throw new Error ("Your app component must have a ViewModel property on its prototype. The ViewModel must be a can.Map constructor.")
-  }
-  //!steal-remove-end
-  
-  var AppState = AppComponent.prototype.ViewModel;
-  function render(appState, options) {
+export default function (AppState, AppComponent) {
+  function render(appMap, options) {
     options = options || {};
 
     // When using ReactDomServer.renderToString, react uses a checksum attribute to identify SSR'd content. 
@@ -35,7 +24,6 @@ export default function (AppComponent) {
     // and this makes React happy.
     var doc = options.document || document;
     var container = IS_BROWSER ? doc : doc.createElement("div");
-
 
     if (!IS_BROWSER) {
       // This condition can be removed once things are stable using CanJS v2.3.15+
@@ -48,40 +36,35 @@ export default function (AppComponent) {
 
     // Ensure data is an instance of AppState
     // This should really only happen on the client
-    if (typeof appState.attr !== "function") {
-      appState = new AppState();
+    if (typeof appMap.attr !== "function") {
+      let newMap = new AppState();
+      newMap.__pageData = can.extend(true, {}, appMap);
+      appMap = newMap;
     }
 
-    route.map(appState);
+    route.map(appMap);
     route.ready();
-
-    var oldUnMount = AppComponent.prototype.componentWillUnmount;
-    AppComponent.prototype.componentWillUnmount = function () {
-      appState.unbind("pageModulePromise", noop);
-      oldUnMount.apply(this, arguments);
-    };
-    appState.bind("pageModulePromise", noop);
     
-    var pageModulePromise = appState.attr('pageModulePromise').then(() => {
-      var app = React.createElement(AppComponent, { __initialState: appState });
+    var pageModulePromise = appMap.attr('pageModulePromise').then(() => {
+      var app = React.createElement(AppComponent, {appMap: appMap});
       ReactDom.render(app, container);
     });
 
-    appState.waitFor(pageModulePromise);
+    appMap.waitFor(pageModulePromise);
   }
 
   // This is only called on the server
-  function renderAsync(renderer, appState, _, document) {
+  function renderAsync(renderer, appMap, _, document) {
     //!steal-remove-start
     var start = Date.now();
     can.dev.log("renderAsync called");
     //!steal-remove-end
 
     // renderer is just a reference to the exported render function above
-    renderer(appState, {document: document});
+    renderer(appMap, {document: document});
 
     return new Promise(function (resolve) {
-      appState.readyPromise().then(function () {
+      appMap.readyPromise().then(function () {
         //!steal-remove-start
         can.dev.log("ALL READY PROMISES RESOLVED IN", Date.now() - start, "MILLISECONDS");
         //!steal-remove-end
@@ -93,12 +76,6 @@ export default function (AppComponent) {
           // Add reacts checksum to the markup - this mimics reacts renderToString technique
           // This allows react to mount to the document without complaining or touching the DOM
           html = ReactMarkupChecksum.addChecksumToMarkup(html);
-          html = html.replace('</body>', '<script>var INLINE_CACHE = ' + JSON.stringify(appState.__pageData) + ';</script></body>');
-
-          // Write the component cache to the output (see can-react component)
-          if (typeof window !== "undefined" && window.COMPONENT_CACHE) {
-            html = html.replace("</body>", "<script>var COMPONENT_CACHE = " + JSON.stringify(window.COMPONENT_CACHE) + ";</script></body>")
-          }
 
           // can-ssr uses document.body.innerHHTML to send output to browser
           document.body = {
@@ -118,7 +95,7 @@ export default function (AppComponent) {
 
   return {
     viewModel: AppState,
-    render,
-    renderAsync
+    render: render,
+    renderAsync: renderAsync
   };
 }

--- a/can-react.js
+++ b/can-react.js
@@ -76,7 +76,7 @@ class BaseComponent extends React.Component {
 	}
 	//!steal-remove-end
 
-	changeHandler (obj, prop) {
+	changeHandler () {
 		// If changes come in during mounting or updating, we need to buffer
 		// those changes and apply them later. TODO: shared event queue.
 		if (!this._isMounted || this._isUpdating) {

--- a/can-react.js
+++ b/can-react.js
@@ -15,7 +15,7 @@ var validateProto = (proto) => {
 	let gis = proto.getInitialState;
 	let render = proto.render;
 	let template = proto.template;
-	
+
 	if (!vm && !gis) {
 		can.dev.warn("You must provide either a ViewModel property or getInitialState method to CanReact.createClass.");
 	}
@@ -29,7 +29,7 @@ var validateProto = (proto) => {
 	}
 
 	if (gis && typeof gis !== "function") {
-		can.dev.warn("getInitialState must be a function which returns an instance of a can.Map - return new ViewModel();");	
+		can.dev.warn("getInitialState must be a function which returns an instance of a can.Map - return new ViewModel();");
 	}
 
 	if (!render && !template) {
@@ -54,7 +54,7 @@ class BaseComponent extends React.Component {
 	}
 
 	// I don't like this - but there needs to be a reliable way to generate unique IDs
-	// that are deterministic - the same on both the server and the client. This is 
+	// that are deterministic - the same on both the server and the client. This is
 	// temporary but works until we can find a better way. Read more about it:
 	// https://github.com/facebook/react/issues/5867
 	getUniqueId (prefix) {
@@ -176,6 +176,15 @@ export default {
 			} else {
 				Component.prototype[prop] = newVal;
 			}
+		});
+
+		// set Function.name to proto.name, this way the React Dev Tools
+		// shows the correct tag name instead of a generic "Component".
+		Object.defineProperty(Component, "name", {
+			writable: false,
+			enumerable: false,
+			configurable: true,
+			value: proto.name || "UnnamedComponent"
 		});
 
 		return Component;

--- a/can-react.js
+++ b/can-react.js
@@ -3,12 +3,10 @@ import ReactDOM from 'react-dom';
 import can from 'can';
 import Map from 'can/map/';
 
-var isNode = (typeof process === 'object' && {}.toString.call(process) === '[object process]');
-
 var thingsNotToMerge = {
 	render: true,
-	getInitialState: true,
-	template: true
+	ViewModel: true,
+	getInitialState: true
 };
 
 //!steal-remove-start
@@ -17,7 +15,7 @@ var validateProto = (proto) => {
 	let gis = proto.getInitialState;
 	let render = proto.render;
 	let template = proto.template;
-
+	
 	if (!vm && !gis) {
 		can.dev.warn("You must provide either a ViewModel property or getInitialState method to CanReact.createClass.");
 	}
@@ -31,7 +29,7 @@ var validateProto = (proto) => {
 	}
 
 	if (gis && typeof gis !== "function") {
-		can.dev.warn("getInitialState must be a function which returns an instance of a can.Map - return new ViewModel();");
+		can.dev.warn("getInitialState must be a function which returns an instance of a can.Map - return new ViewModel();");	
 	}
 
 	if (!render && !template) {
@@ -48,62 +46,24 @@ function misusedMethod (methodName) {
 }
 //!steal-remove-end
 
-function getStaticUniqueId () {
-	if (this._reactInternalInstance && this._reactInternalInstance._rootNodeID) {
-		return this._reactInternalInstance._rootNodeID;
-	}
-	return "";
-}
-
-function cacheComponentState () {
-	var win = window || global;
-	if (!win.COMPONENT_CACHE) {
-		win.COMPONENT_CACHE = {};
-	}
-	win.COMPONENT_CACHE[ this.__id ] = (this.state.serialize ? this.state.serialize() : this.state);
-}
-
-function deleteComponentCache () {
-	var win = window || global;
-	if (win.COMPONENT_CACHE && win.COMPONENT_CACHE[ this.__id ]) {
-		delete win.COMPONENT_CACHE[ this.__id ];
-	}
-}
-
-function applyComponentCache () {
-	var win = window || global;
-	if (win.COMPONENT_CACHE && win.COMPONENT_CACHE[ this.__id ]) {
-		let data = win.COMPONENT_CACHE[ this.__id ];
-
-		if (this.state.attr) {
-			this.state.attr(data);
-		} else {
-			can.extend(this.state, data);
-		}
-
-		deleteComponentCache.call(this);
-	}
-}
-
 class BaseComponent extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.__id = getStaticUniqueId.call(this);
 		this.changeHandler = this.changeHandler.bind(this);
 	}
 
 	// I don't like this - but there needs to be a reliable way to generate unique IDs
-	// that are deterministic - the same on both the server and the client. This is
-	// temporary but works until we can find a better way. Read more about it here:
+	// that are deterministic - the same on both the server and the client. This is 
+	// temporary but works until we can find a better way. Read more about it:
 	// https://github.com/facebook/react/issues/5867
 	getUniqueId (prefix) {
 		if ( !this._uniqueIdIndex ) {
 			this._uniqueIdIndex = 0;
 		}
-
-		prefix = (prefix || "") + this.__id + "_";
-
+		if (this._reactInternalInstance && this._reactInternalInstance._rootNodeID) {
+			prefix = (prefix || "") + this._reactInternalInstance._rootNodeID + "_";
+		}
 		return prefix + this._uniqueIdIndex++;
 	}
 
@@ -116,44 +76,14 @@ class BaseComponent extends React.Component {
 	}
 	//!steal-remove-end
 
-	changeHandler () {
-		// If not mounted, don't do anything. If it's about to mount, it will render
-		// the proper state when it mounts. If it has been unmounted... well, hopefully we
-		// don't have a memory leak.
-		if (!this._isMounted) {
-			return;
-		}
-
-		// If the component tries to update itself while rendering, then we need to
-		// buffer the update and apply it later. This most likely happens when a child component
-		// updates its parent (ex. Page component sets the AppState page title during mount).
-		// During SSR, we want to save the new state to the COMPONENT_CACHE so that it's
-		// used during initial render on the client.
-		if (this._isUpdating) {
+	changeHandler (obj, prop) {
+		// If changes come in during mounting or updating, we need to buffer
+		// those changes and apply them later. TODO: shared event queue.
+		if (!this._isMounted || this._isUpdating) {
 			clearTimeout(this.__updateTimer);
 			this.__updateTimer = setTimeout(this.changeHandler, 40);
-			this.__saveNextState = true;
+			return;
 		}
-
-		if (isNode) {
-			// If this flag is set to true, then delete any state that was previously saved to the
-			// COMPONENT_CACHE as it's now stale. If this new state needs to be saved, we do that below.
-			if (this.__deleteCachedState) {
-				deleteComponentCache.call(this);
-				this.__deleteCachedState = false;
-			}
-
-			// If we are about to render a buffered update, we want to save the data to
-			// COMPONENT_CACHE for use during initial render in the client. We also set a flag
-			// so that if the state changes again, we delete the data in the COMPONENT_CACHE
-			// since it will be stale.
-			if (this.__saveNextState) {
-				cacheComponentState.call(this);
-				this.__saveNextState = false;
-				this.__deleteCachedState = true;
-			}
-		}
-
 		// Calling React's prototype method skips the dev-mode warning
 		// This is the only place in the app that should call forceUpdate
 		React.Component.prototype.forceUpdate.call(this);
@@ -197,26 +127,19 @@ export default {
 			constructor (props) {
 				super(props);
 
-				if (props.__initialState) {
-					// This is used during server side rendering. The app viewModel is
-					// instantiated _before_ the component is initialized, and the state
-					// is passed in on the __initialState prop.
-					this.state = props.__initialState;
-				} else {
-					this.state = {};
-					if (proto.ViewModel) {
-						this.state = new proto.ViewModel( can.extend({}, props) );
-					}
+				this.state = {};
+				if (proto.ViewModel) {
+					this.state = new proto.ViewModel( can.extend({}, props) );
+				}
 
-					if (proto.getInitialState) {
-						this.state = proto.getInitialState.call(this);
+				if (proto.getInitialState) {
+					this.state = proto.getInitialState.call(this);
 
-						//!steal-remove-start
-						if ( !(this.state instanceof Map) ) {
-							can.dev.error("When using the 'getInitialState' method with the can-react component, you must return an instance of can.Map - return new can.Map(this.props);");
-						}
-						//!steal-remove-end
+					//!steal-remove-start
+					if ( !(this.state instanceof Map) ) {
+						can.dev.error("When using the 'getInitialState' method with the can-react component, you must return an instance of can.Map - return new can.Map(this.props);");
 					}
+					//!steal-remove-end
 				}
 
 				if (proto.template) {
@@ -225,7 +148,6 @@ export default {
 					};
 				}
 
-				applyComponentCache.call(this);
 				this.renderer = can.compute(proto.render.bind(this));
 			}
 		}
@@ -254,15 +176,6 @@ export default {
 			} else {
 				Component.prototype[prop] = newVal;
 			}
-		});
-
-		// set Function.name to proto.name, this way the React Dev Tools
-		// shows the correct tag name instead of a generic "Component".
-		Object.defineProperty(Component, "name", {
-			writable: false,
-			enumerable: false,
-			configurable: true,
-			value: proto.name || "UnnamedComponent"
 		});
 
 		return Component;

--- a/extensions/can-ssr-app-map.js
+++ b/extensions/can-ssr-app-map.js
@@ -20,18 +20,18 @@ AppMap.prototype.__pluckPromise = function (promise) {
 			}
 		});
 	}
-}
+};
 
 AppMap.prototype.waitFor = function(promise) {
 	this.__readyPromises.push(promise);
 
 	//!steal-remove-start
-	// Clever little way of getting the module path and line 
+	// Clever little way of getting the module path and line
 	// number where this promise is defined (3rd line of stack).
 	var err = new Error();
 	var parentFile = err.stack.split(/[\r\n]/)[2].split("/").slice(1).join("/");
 	//!steal-remove-end
-	
+
 	promise.then(() => {
 		this.__pluckPromise(promise);
 	}, (err) => {

--- a/extensions/can-ssr-app-map.js
+++ b/extensions/can-ssr-app-map.js
@@ -20,7 +20,7 @@ AppMap.prototype.__pluckPromise = function (promise) {
 			}
 		});
 	}
-};
+}
 
 AppMap.prototype.waitFor = function(promise) {
 	this.__readyPromises.push(promise);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-react",
-  "version": "0.0.18",
+  "version": "0.0.16",
   "description": "A compatibility layer required to enable donejs-react.",
   "main": "can-react.js",
   "scripts": {


### PR DESCRIPTION
The v0.0.17 release broke much for us.

There was not a clear pat forward, so @DesignByOnyx suggested we revert the 0.0.17 release and apply v0.0.18 on top of that for a v0.0.19 release.

I agreed and here we are.