### PR TITLE
err.stack not defined in ie11 unless/until the error is thrown or customized

### DIFF
--- a/extensions/can-ssr-app-map.js
+++ b/extensions/can-ssr-app-map.js
@@ -29,7 +29,7 @@ AppMap.prototype.waitFor = function(promise) {
 	// Clever little way of getting the module path and line
 	// number where this promise is defined (3rd line of stack).
 	var err = new Error();
-	var parentFile = err.stack.split(/[\r\n]/)[2].split("/").slice(1).join("/");
+	var parentFile = err.stack && err.stack.split(/\r?\n/)[2].split("/").slice(1).join("/") || "err.stack undefined";
 	//!steal-remove-end
 
 	promise.then(() => {


### PR DESCRIPTION
bug prevents dev work in ie11