### PR TITLE
Add can-simple-dom to the dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-react",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "A compatibility layer required to enable donejs-react.",
   "main": "can-react.js",
   "scripts": {
@@ -26,6 +26,7 @@
   "dependencies": {
     "can": "~2.3.2",
     "can-connect": "~0.3.3",
+    "can-simple-dom": "^0.4.2",
     "can-ssr": "~0.10.1",
     "jquery": "~2.1.4",
     "react": "~0.14.3"


### PR DESCRIPTION
`can-simple-dom` is imported https://github.com/canjs/can-react/blob/master/extensions/can-simple-dom.js#L3

But is not declared as a dependancy. This appears to be causing some intermittent failures.