### PR TITLE
Latest `can-simple-dom` does not work when `can-react` is run on `can…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-react",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "A compatibility layer required to enable donejs-react.",
   "main": "can-react.js",
   "scripts": {
@@ -26,7 +26,7 @@
   "dependencies": {
     "can": "~2.3.2",
     "can-connect": "~0.3.3",
-    "can-simple-dom": "^0.4.2",
+    "can-simple-dom": "0.3.0",
     "can-ssr": "~0.10.1",
     "jquery": "~2.1.4",
     "react": "~0.14.3"


### PR DESCRIPTION
…-ssr`, pinning version to `0.3.0`