### PR TITLE
Unmount component at the container node after render.

### DIFF
--- a/autorender.js
+++ b/autorender.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDom from "react-dom";
+import ReactDOM from "react-dom";
 import ReactMarkupChecksum from "react/lib/ReactMarkupChecksum";
 
 import can from 'can/util/';
@@ -16,14 +16,14 @@ export default function (AppState, AppComponent) {
   function render(appMap, options) {
     options = options || {};
 
-    // When using ReactDomServer.renderToString, react uses a checksum attribute to identify SSR'd content. 
+    // When using ReactDomServer.renderToString, react uses a checksum attribute to identify SSR'd content.
     // If we try to RenderDom directly to the document during SSR, React will bark because
     // it is expecting to bind to a checksum'd element (ask Ryan Wheale (@DesignByOnyx) for full explanation).
     // When rendering server-side, we render to a DIV.
     // This is possible because can-simple-dom will allow an HTML element as a child to a DIV,
     // and this makes React happy.
-    var doc = options.document || document;
-    var container = IS_BROWSER ? doc : doc.createElement("div");
+    let doc = options.document || document;
+    let container = IS_BROWSER ? doc : doc.createElement("div");
 
     if (!IS_BROWSER) {
       // This condition can be removed once things are stable using CanJS v2.3.15+
@@ -44,12 +44,13 @@ export default function (AppState, AppComponent) {
 
     route.map(appMap);
     route.ready();
-    
+
     var pageModulePromise = appMap.attr('pageModulePromise').then(() => {
       var app = React.createElement(AppComponent, {appMap: appMap});
-      ReactDom.render(app, container);
+      ReactDOM.render(app, container);
     });
 
+    appMap.canReactContainer = container;
     appMap.waitFor(pageModulePromise);
   }
 
@@ -71,11 +72,54 @@ export default function (AppState, AppComponent) {
 
         // A timeout is necessary to let react finish rendering asynchronously loaded content
         setTimeout(() => {
-          let html = document.body.firstChild.innerHTML;
+          let container = appMap.canReactContainer;
+          let htmlElement = container.firstChild;
+          let headElement = htmlElement.firstChild;
+          let bodyElement = headElement.nextSibling;
+
+          let getAttributes = element => {
+            let attributes = element.attributes.map(attribute => {
+              return `${attribute.name}="${attribute.value}"`;
+            });
+
+            return attributes.join(' ');
+          };
+
+          // React restricts its component unmount functions to the least common
+          // denominator. It will not unmount components with html, head, or
+          // body in its tree because of "cross-browser quirks". However, we
+          // must prevent React's internal references
+          // (e.g. instancesByReactRootID) from continually growing with every
+          // page request. We have no choice but to unmount root components.
+          // To work around this, we won't use html, head, or body tags when
+          // rendering React. We transform our response into a valid html
+          // document based on the document structure.
+          //
+          // e.g. root document structure:
+          // ```
+          // <div>  --> <html>
+          //   <div>  --> <head>
+          //   </div> --> </head>
+          //   <div>  --> <body>
+          //   </div> --> </body>
+          // </div> --> </html>
+          // ```
+          let html = [
+            `<html ${getAttributes(htmlElement)}>`,
+              `<head ${getAttributes(headElement)}>`,
+                headElement.innerHTML,
+              '</head>',
+              `<body ${getAttributes(bodyElement)}>`,
+                bodyElement.innerHTML,
+              '</body>',
+            '</html>'
+          ].join('');
 
           // Add reacts checksum to the markup - this mimics reacts renderToString technique
           // This allows react to mount to the document without complaining or touching the DOM
           html = ReactMarkupChecksum.addChecksumToMarkup(html);
+
+          ReactDOM.unmountComponentAtNode(container) || console.error('can-react document failed to unmount');
 
           // can-ssr uses document.body.innerHHTML to send output to browser
           document.body = {

--- a/isomorphic-tag.js
+++ b/isomorphic-tag.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+/**
+ * @module IsomorphicTag IsomorphicTag
+ *
+ * React restricts its component unmount functions to the least common
+ * denominator. It will not unmount components with html, head, or body in its
+ * tree because of "cross-browser quirks".
+ * However, on the server -- where there are no "cross-browser quirks" -- we
+ * must prevent React's internal references (e.g. instancesByReactRootID)
+ * from continually growing with every page request. We have no choice but to
+ * unmount root components on the server.
+ * To work around this, we won't use html, head, or body tags when rendering
+ * React on the server. `autorender` will transform its response into a valid
+ * html document based on the document structure.
+ *
+ * e.g. root document structure:
+ * ```
+ * <div>  --> <html>
+ *   <div>  --> <head>
+ *   </div> --> </head>
+ *   <div>  --> <body>
+ *   </div> --> </body>
+ * </div> --> </html>
+ * ```
+ */
+export default React.createClass({
+  render() {
+    const isServer = typeof process === 'object' && {}.toString.call(process) === '[object process]';
+    const tag = isServer ? 'div' : this.props['data-node'];
+    const attributes = Object.keys(this.props).reduce(
+      (aggregate, key) => {
+        if (key !== 'children') {
+          aggregate[key] = this.props[key];
+        }
+
+        return aggregate;
+      },
+      {}
+    );
+
+    return React.createElement(tag, attributes, this.props.children);
+  }
+});


### PR DESCRIPTION
This fixes a memory leak by:

1) Providing the IsomorphicTag component, which allows you to render a
given html tag (like head and body) on the client but it will render a
`div` on the server, since React does not allow unmounting tags like
html, body and head.

2) autorender will get the innerHTML of the `div` tags containing the
children of the blacklisted tags mentioned above, and will generate a
valid HTML document to be sent to the client

The goal of this is to be able to call ReactDOM.unmountComponentAtNode
on the container element created during server side rendering so React
can free up its internal references, preventing a memory leak.

Closes #12