### PR TITLE
Pin down can-connect version to 0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/canjs/can-react#readme",
   "dependencies": {
     "can": "^2.3.2",
-    "can-connect": "^0.5.5",
+    "can-connect": "0.3.6",
     "can-simple-dom": "0.3.0",
     "can-ssr": "~0.10.1",
     "jquery": "~2.1.4",


### PR DESCRIPTION
Something changed in v0.5.x that breaks anything using the inline-cache extension.